### PR TITLE
Create bandersnatch.bat

### DIFF
--- a/bandersnatch.bat
+++ b/bandersnatch.bat
@@ -1,0 +1,1 @@
+start chrome --allow-file-access-from-files --allow-file-access --allow-cross-origin-auth-prompt file://%~dp0/index.html


### PR DESCRIPTION
This is a batch file that starts index.html in chrome with some flags that fix the error when trying to load subtitles when opening index.html as a local file instead of loading it through a web server